### PR TITLE
SQLite busy handler

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,6 +26,7 @@ const voiceWorkDefaultPath = () => {
 
 const defaultConfig = {
   version: pjson.version,
+  dbBusyTimeout: 1000,
   checkUpdate: true,
   checkBetaUpdate: false,
   maxParallelism: 16,

--- a/database/db.js
+++ b/database/db.js
@@ -23,8 +23,16 @@ const knex = require('knex')({
   },
   acquireConnectionTimeout: 40000, // 连接计时器
   pool: {
-    afterCreate: (conn, cb) => {
-      conn.run('PRAGMA foreign_keys = ON', cb)
+    afterCreate: (conn, done) => {
+      conn.run('PRAGMA foreign_keys = ON;', function (err) {
+        if (err) {
+          done(err, conn);
+        } else {
+          conn.run(`PRAGMA busy_timeout = ${config.dbBusyTimeout};`, function (err) {
+            done(err, conn);
+          });
+        }
+      });
     }
   }
 });


### PR DESCRIPTION
增加SQLite3 busy等待时间到1秒，SQLite好像默认根本没有开启busy handler.……  
另外这个不一定有用，如果检测到deadlock仍然会抛出SQLITE_BUSY