### PR TITLE
Nuke N+1 queries

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,7 @@ app.use((err, req, res, next) => {
       res.status(500).send({ error: '数据库结构尚未建立，请先执行扫描.'});
     }
   } else {
+    console.error(err);
     res.status(500).send({ error: err.message || err });
   }
 });

--- a/app.js
+++ b/app.js
@@ -56,7 +56,7 @@ app.use((err, req, res, next) => {
       res.status(500).send({ error: '数据库结构尚未建立，请先执行扫描.'});
     }
   } else {
-    console.error(err);
+    console.error(new Date().toJSON(), 'Kikoeru log:', err);
     res.status(500).send({ error: err.message || err });
   }
 });

--- a/database/db.js
+++ b/database/db.js
@@ -494,7 +494,7 @@ const deleteUserReview = (username, workid) => knex.transaction(trx => trx('t_re
   .del());
 
 // TODO 写migration
-const getWorksWithReviews = ({username = '', limit = 1000, offset = 0, orderBy = 'release', sortOption = 'desc', filter} = {}) => knex.transaction(async(trx) => {
+const getWorksWithReviews = async ({username = '', limit = 1000, offset = 0, orderBy = 'release', sortOption = 'desc', filter} = {}) => {
   // await trx.raw(
   //   `CREATE VIEW IF NOT EXISTS userMetadata AS
   //     SELECT t_work.id,
@@ -532,7 +532,7 @@ const getWorksWithReviews = ({username = '', limit = 1000, offset = 0, orderBy =
   
   let works = [];
   let totalCount = 0;
-  let query = () => trx('userMetadata').where('user_name', '=', username)
+  let query = () => knex('userMetadata').where('user_name', '=', username)
   .orderBy(orderBy, sortOption).orderBy([{ column: 'release', order: 'desc'}, { column: 'id', order: 'desc' }]);
 
   if (filter) {
@@ -552,7 +552,7 @@ const getWorksWithReviews = ({username = '', limit = 1000, offset = 0, orderBy =
   }
 
   return {works, totalCount};
-});
+};
 
 module.exports = {
   knex, insertWorkMetadata, getWorkMetadata, removeWork, getWorksBy, getWorksByKeyWord, updateWorkMetadata, getLabels,

--- a/database/db.js
+++ b/database/db.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 const { config } = require('../config');
-const { strftime } = require('./strftime')
 
 const databaseFolderDir = config.databaseFolderDir;
 if (!fs.existsSync(databaseFolderDir)) {
@@ -146,84 +145,25 @@ const updateWorkMetadata = (work, options = {}) => knex.transaction(async (trx) 
  * @param {Number} id Work identifier.
  * @param {String} username 'admin' or other usernames for current user
  */
-const getWorkMetadata = (id, username) => new Promise((resolve, reject) => {
+const getWorkMetadata = async (id, username) => {
   // TODO: do this all in a single transaction?
   // <= Yes, WTF is this
+  // I think we are done.
 
-    knex.raw(`
-    SELECT t_work.*,
-      t_circle.name AS circlename,
-      t_tag.id AS tagid,
-      t_tag.name AS tagname,
-      t_va.id AS vaid,
-      t_va.name AS vaname,
-      userrate.rating,
-      userrate.review_text,
-      userrate.progress,
-      datetime(userrate.updated_at,'localtime')
-    FROM t_work
-      JOIN t_circle on t_circle.id = t_work.circle_id
-      LEFT JOIN r_tag_work on r_tag_work.work_id = t_work.id
-      LEFT JOIN t_tag on t_tag.id = r_tag_work.tag_id
-      JOIN r_va_work on r_va_work.work_id = t_work.id
-      join t_va on t_va.id = r_va_work.va_id
-      LEFT JOIN (
-        SELECT t_review.work_id,
-          t_review.rating,
-          t_review.review_text,
-          t_review.progress,
-          t_review.updated_at
-        FROM t_review
-          JOIN t_work on t_work.id = t_review.work_id
-          JOIN t_user on t_review.user_name = t_user.name
-        WHERE t_review.user_name = ?
-      ) AS userrate
-      ON userrate.work_id = t_work.id
-    WHERE t_work.id = ?;`, [username, id])
-      .then(res => {
-        if (res.length === 0) throw new Error(`There is no work with id ${id} in the database.`);
-        let work = {};
-        let result = res[0];
-        work.id= result.id;
-        work.title= result.title;
-        work.circle= {id: result.circle_id, name: result.circlename};
-        work.nsfw= Boolean(result.nsfw);
-        work.release= result.release;
+    const ratingSubQuery = knex('t_review')
+    .select(['t_review.work_id', 't_review.rating AS userRating', 't_review.review_text', 't_review.progress', knex.raw('strftime(\'%Y-%m-%d %H-%M-%S\', t_review.updated_at, \'localtime\') AS updated_at'), 't_review.user_name'])
+    .join('t_work', 't_work.id', 't_review.work_id')
+    .where('t_review.user_name', username).as('userrate');
 
-        work.dl_count= result.dl_count;
-        work.price= result.price;
-        work.review_count= result.review_count;
-        work.rate_count= result.rate_count;
-        work.rate_average_2dp= result.rate_average_2dp;
-        work.rate_count_detail= JSON.parse(result.rate_count_detail);
-        work.rank= result.rank ? JSON.parse(result.rank) : null;
+    let query = () => knex('staticMetadata')
+      .select(['staticMetadata.*', 'userrate.userRating', 'userrate.review_text', 'userrate.progress', 'userrate.updated_at', 'userrate.user_name'])
+      .leftJoin(ratingSubQuery, 'userrate.work_id', 'staticMetadata.id')
+      .where('id', '=', id);
 
-        // Get unique tags and vas records
-        let tags = new Set();
-        let vas = new Set();
-        let tagRecord = [];
-        let vasRecord = [];
-        for (let record of res) {
-          if (!tags.has(record.tagname)) {
-            tags.add(record.tagname);
-            tagRecord.push({id: record.tagid, name: record.tagname});
-          }
-          if (!vas.has(record.vaname)) {
-            vas.add(record.vaname);
-            vasRecord.push({id: record.vaid, name: record.vaname});
-          }
-        }
-        work.tags = tagRecord;
-        work.vas = vasRecord;
-
-        work.userRating= result.rating;
-        work.progress = result.progress;
-        work.review_text = result.review_text;
-
-        resolve(work);
-      })
-    .catch(err => reject(err));
-});
+    const work = await query();
+    if (work.length === 0) throw new Error(`There is no work with id ${id} in the database.`);
+    return work;
+};
 
 /**
  * Tests if the given circle, tags and VAs are orphans and if so, removes them.
@@ -323,34 +263,29 @@ const getWorksBy = ({id, field, username = ''} = {}) => {
   const ratingSubQuery = knex('t_review')
     .select(['t_review.work_id', 't_review.rating'])
     .join('t_work', 't_work.id', 't_review.work_id')
-    .join('t_user', 't_user.name', 't_review.user_name')
     .where('t_review.user_name', username).as('userrate')
   
   switch (field) {
     case 'circle':
-      return knex('t_work')
-        .select('id')
-        .leftJoin(ratingSubQuery, 'userrate.work_id', 't_work.id')
+      return knex('staticMetadata').select(['staticMetadata.*', 'userrate.rating AS userRating'])
+        .leftJoin(ratingSubQuery, 'userrate.work_id', 'staticMetadata.id')
         .where('circle_id', '=', id);
 
     case 'tag':
       workIdQuery = knex('r_tag_work').select('work_id').where('tag_id', '=', id);
-      return knex('t_work')
-        .select('id')
-        .leftJoin(ratingSubQuery, 'userrate.work_id', 't_work.id')
+      return knex('staticMetadata').select(['staticMetadata.*', 'userrate.rating AS userRating'])
+        .leftJoin(ratingSubQuery, 'userrate.work_id', 'staticMetadata.id')
         .where('id', 'in', workIdQuery);
 
     case 'va':
       workIdQuery = knex('r_va_work').select('work_id').where('va_id', '=', id);
-      return knex('t_work')
-        .select('id')
-        .leftJoin(ratingSubQuery, 'userrate.work_id', 't_work.id')
+      return knex('staticMetadata').select(['staticMetadata.*', 'userrate.rating AS userRating'])
+        .leftJoin(ratingSubQuery, 'userrate.work_id', 'staticMetadata.id')
         .where('id', 'in', workIdQuery);
 
     default:
-      return knex('t_work')
-        .select('id')
-        .leftJoin(ratingSubQuery, 'userrate.work_id', 't_work.id');
+      return knex('staticMetadata').select(['staticMetadata.*', 'userrate.rating AS userRating'])
+        .leftJoin(ratingSubQuery, 'userrate.work_id', 'staticMetadata.id');
   }
 };
 
@@ -362,14 +297,12 @@ const getWorksByKeyWord = ({keyword, username = 'admin'} = {}) => {
   const ratingSubQuery = knex('t_review')
   .select(['t_review.work_id', 't_review.rating'])
   .join('t_work', 't_work.id', 't_review.work_id')
-  .join('t_user', 't_user.name', 't_review.user_name')
   .where('t_review.user_name', username).as('userrate')
 
   const workid = keyword.match(/((R|r)(J|j))?(\d{6})/) ? keyword.match(/((R|r)(J|j))?(\d{6})/)[4] : '';
   if (workid) {
-    return knex('t_work')
-      .select('id', 'release', 'rating', 'dl_count', 'review_count', 'price', 'rate_average_2dp')
-      .leftJoin(ratingSubQuery, 'userrate.work_id', 't_work.id')
+    return knex('staticMetadata').select(['staticMetadata.*', 'userrate.rating AS userRating'])
+      .leftJoin(ratingSubQuery, 'userrate.work_id', 'staticMetadata.id')
       .where('id', '=', workid);
   }
 
@@ -383,9 +316,8 @@ const getWorksByKeyWord = ({keyword, username = 'admin'} = {}) => {
   ]);
 
 
-  return knex('t_work')
-    .select('id', 'rating', 'release', 'dl_count', 'review_count', 'price', 'rate_average_2dp', 'nsfw')
-    .leftJoin(ratingSubQuery, 'userrate.work_id', 't_work.id')
+  return knex('staticMetadata').select(['staticMetadata.*', 'userrate.rating AS userRating'])
+    .leftJoin(ratingSubQuery, 'userrate.work_id', 'staticMetadata.id')
     .where('title', 'like', `%${keyword}%`)
     .orWhere('circle_id', 'in', circleIdQuery)
     .orWhere('id', 'in', workIdQuery);
@@ -487,53 +419,26 @@ const updateUserReview = async (username, workid, rating, review_text = '', prog
     }
 });
 
-// 删除星标及评语
+// 删除星标、评语及进度
 const deleteUserReview = (username, workid) => knex.transaction(trx => trx('t_review')
   .where('user_name', '=', username)
   .andWhere('work_id', '=', workid)
   .del());
 
-// TODO 写migration
+// 读取星标及评语 + 作品元数据
 const getWorksWithReviews = async ({username = '', limit = 1000, offset = 0, orderBy = 'release', sortOption = 'desc', filter} = {}) => {
-  // await trx.raw(
-  //   `CREATE VIEW IF NOT EXISTS userMetadata AS
-  //     SELECT t_work.id,
-  //       t_work.title,
-  //       json_object('id', t_work.circle_id, 'name', t_circle.name) AS circleObj,
-  //       t_work.release,
-  //       t_work.review_count,
-  //       t_work.dl_count,
-  //       t_work.nsfw,
-  //       t_va.id AS vaid,
-  //       t_va.name AS vaname,
-  //       userrate.userRating,
-  //       userrate.review_text,
-  //       userrate.progress,
-  //       userrate.updated_at,
-  //       json_object('vas', json_group_array(json_object('id', t_va.id, 'name', t_va.name))) AS vaObj,
-  //       userrate.user_name
-  //     FROM t_work
-  //     JOIN t_circle on t_circle.id = t_work.circle_id
-  //     JOIN r_va_work on r_va_work.work_id = t_work.id
-  //     join t_va on t_va.id = r_va_work.va_id
-  //     JOIN (
-  //         SELECT t_review.work_id,
-  //           t_review.rating AS userRating,
-  //           t_review.review_text,
-  //           t_review.progress,
-  //           strftime('%Y-%m-%d %H-%M-%S', t_review.updated_at, 'localtime') AS updated_at,
-  //           t_review.user_name
-  //         FROM t_review
-  //           JOIN t_work on t_work.id = t_review.work_id
-  //         ) AS userrate
-  //     ON userrate.work_id = t_work.id
-  //     GROUP BY t_work.id, userrate.user_name
-  // `);
-  
   let works = [];
   let totalCount = 0;
-  let query = () => knex('userMetadata').where('user_name', '=', username)
-  .orderBy(orderBy, sortOption).orderBy([{ column: 'release', order: 'desc'}, { column: 'id', order: 'desc' }]);
+
+  const ratingSubQuery = knex('t_review')
+  .select(['t_review.work_id', 't_review.rating AS userRating', 't_review.review_text', 't_review.progress', knex.raw('strftime(\'%Y-%m-%d %H-%M-%S\', t_review.updated_at, \'localtime\') AS updated_at'), 't_review.user_name'])
+  .join('t_work', 't_work.id', 't_review.work_id')
+  .where('t_review.user_name', username).as('userrate');
+
+  let query = () => knex('staticMetadata')
+    .select(['staticMetadata.*', 'userrate.userRating', 'userrate.review_text', 'userrate.progress', 'userrate.updated_at', 'userrate.user_name'])
+    .join(ratingSubQuery, 'userrate.work_id', 'staticMetadata.id')
+    .orderBy(orderBy, sortOption).orderBy([{ column: 'release', order: 'desc'}, { column: 'id', order: 'desc' }]);
 
   if (filter) {
     totalCount = await query().where('progress', '=', filter).count('id as count');
@@ -541,14 +446,6 @@ const getWorksWithReviews = async ({username = '', limit = 1000, offset = 0, ord
   } else {
     totalCount = await query().count('id as count');
     works = await query().limit(limit).offset(offset);
-  }
-
-  if (works.length > 0) {
-    works.map(record => {
-      record.circle = JSON.parse(record.circleObj);
-      record.vas = JSON.parse(record.vaObj)['vas'];
-      record.updated_at = strftime('%F', record.updated_at);
-    })
   }
 
   return {works, totalCount};

--- a/database/migrations/20210307061415_refactor_queries.js
+++ b/database/migrations/20210307061415_refactor_queries.js
@@ -1,0 +1,40 @@
+exports.up = async function(knex) {
+  await knex.raw(`
+    CREATE VIEW IF NOT EXISTS staticMetadata AS
+    SELECT baseQueryWithVA.*,
+      json_object('tags', json_group_array(json_object('id', t_tag.id, 'name', t_tag.name))) AS tagObj
+    FROM (
+      SELECT baseQuery.*,
+        json_object('vas', json_group_array(json_object('id', t_va.id, 'name', t_va.name))) AS vaObj
+      FROM (
+        SELECT t_work.id, 
+          t_work.title,
+          t_work.circle_id,
+          t_circle.name,
+          json_object('id', t_work.circle_id, 'name', t_circle.name) AS circleObj,
+          t_work.nsfw,
+          t_work.release,
+          t_work.dl_count,
+          t_work.price,
+          t_work.review_count,
+          t_work.rate_count,
+          t_work.rate_average_2dp,
+          t_work.rate_count_detail,
+          t_work.rank
+        FROM t_work
+        JOIN t_circle ON t_circle.id = t_work.circle_id
+      ) AS baseQuery
+      JOIN r_va_work ON r_va_work.work_id = baseQuery.id
+      JOIN t_va ON t_va.id = r_va_work.va_id
+      GROUP BY baseQuery.id
+    ) AS baseQueryWithVA
+    LEFT JOIN r_tag_work ON r_tag_work.work_id = baseQueryWithVA.id
+    LEFT JOIN t_tag ON t_tag.id = r_tag_work.tag_id
+    GROUP BY baseQueryWithVA.id;
+  `)
+};
+
+// Will break most of the queries! You will need to switch to an earlier version of code.
+exports.down = async function(knex) {
+  knex.raw(`DROP VIEW IF EXISTS staticMetadata`)
+};

--- a/database/schema.js
+++ b/database/schema.js
@@ -66,6 +66,39 @@ const createSchema = () => knex.schema
     table.foreign('work_id').references('id').inTable('t_work').onDelete('CASCADE'); // FOREIGN KEY 
     table.primary(['user_name', 'work_id']); // PRIMARY KEY
   })
+  .raw(`
+    CREATE VIEW IF NOT EXISTS staticMetadata AS
+    SELECT baseQueryWithVA.*,
+      json_object('tags', json_group_array(json_object('id', t_tag.id, 'name', t_tag.name))) AS tagObj
+    FROM (
+      SELECT baseQuery.*,
+        json_object('vas', json_group_array(json_object('id', t_va.id, 'name', t_va.name))) AS vaObj
+      FROM (
+        SELECT t_work.id, 
+          t_work.title,
+          t_work.circle_id,
+          t_circle.name,
+          json_object('id', t_work.circle_id, 'name', t_circle.name) AS circleObj,
+          t_work.nsfw,
+          t_work.release,
+          t_work.dl_count,
+          t_work.price,
+          t_work.review_count,
+          t_work.rate_count,
+          t_work.rate_average_2dp,
+          t_work.rate_count_detail,
+          t_work.rank
+        FROM t_work
+        JOIN t_circle ON t_circle.id = t_work.circle_id
+      ) AS baseQuery
+      JOIN r_va_work ON r_va_work.work_id = baseQuery.id
+      JOIN t_va ON t_va.id = r_va_work.va_id
+      GROUP BY baseQuery.id
+    ) AS baseQueryWithVA
+    LEFT JOIN r_tag_work ON r_tag_work.work_id = baseQueryWithVA.id
+    LEFT JOIN t_tag ON t_tag.id = r_tag_work.tag_id
+    GROUP BY baseQueryWithVA.id;
+  `)
   .then(() => {
     console.log(' * 成功构建数据库结构.');
   })

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -17,6 +17,7 @@ router.post('/me', [
   check('password')
     .isLength({ min: 5 })
     .withMessage('密码长度至少为 5')
+// eslint-disable-next-line no-unused-vars
 ], (req, res, next) => {
   // Finds the validation errors in this request and wraps them in an object with handy functions
   const errors = validationResult(req);
@@ -40,7 +41,9 @@ router.post('/me', [
       }
     })
     .catch((err) => {
-      next(err);
+      console.error(err);
+      res.status(500).send({error: '服务器错误'});
+      // next(err);
     });
 });
 
@@ -73,6 +76,7 @@ if (config.publicRegistration) {
     check('password')
         .isLength({min: 5})
         .withMessage('密码长度至少为 5'),
+  // eslint-disable-next-line no-unused-vars
   ], (req, res, next) => {
     // Finds the validation errors in this request and wraps them in an object with handy functions
     const errors = validationResult(req);
@@ -105,7 +109,9 @@ if (config.publicRegistration) {
             if (err.message.indexOf('已存在') !== -1) {
                 res.status(403).send({error: err.message});
             } else {
-                next(err);
+              console.error(err);
+              res.status(500).send({error: '服务器错误'});
+                // next(err);
             }
         });
 

--- a/routes/media.js
+++ b/routes/media.js
@@ -38,7 +38,8 @@ router.get('/stream/:id/:index', (req, res, next) => {
       } else {
         res.status(500).send({error: `找不到文件夹: "${work.root_folder}"，请尝试重启服务器或重新扫描.`});
       }
-    });
+    })
+    .catch(err => next(err));
 });
 
 router.get('/download/:id/:index', (req, res, next) => {
@@ -94,7 +95,8 @@ router.get('/check-lrc/:id/:index', (req, res, next) => {
       } else {
         res.status(500).send({error: `找不到文件夹: "${work.root_folder}"，请尝试重启服务器或重新扫描.`});
       }
-    });
+    })
+    .catch(err => next(err));
 });
 
 module.exports = router;

--- a/routes/metadata.js
+++ b/routes/metadata.js
@@ -90,7 +90,7 @@ router.get('/works', async (req, res, next) => {
       }
     });
   } catch(err) {
-    res.status(500).send({error: '查询过程中出错'});
+    res.status(500).send({error: '服务器错误'});
     console.error(err)
     // next(err);
   }
@@ -144,7 +144,8 @@ router.get('/search/:keyword?', async (req, res, next) => {
     });
   } catch(err) {
     res.status(500).send({error: '查询过程中出错'});
-    next(err);
+    console.error(err);
+    // next(err);
   }
 });
 
@@ -182,7 +183,8 @@ router.get('/:field/:id', async (req, res, next) => {
     });
   } catch(err) {
     res.status(500).send({error: '查询过程中出错'});
-    next(err);
+    console.error(err);
+    // next(err);
   }
 });
 

--- a/routes/metadata.js
+++ b/routes/metadata.js
@@ -110,6 +110,7 @@ router.get('/get-name/:field/:id', (req, res, next) => {
     .catch(err => next(err));
 });
 
+// eslint-disable-next-line no-unused-vars
 router.get('/search/:keyword?', async (req, res, next) => {
   const keyword = req.params.keyword ? req.params.keyword.trim() : '';
   const currentPage = parseInt(req.query.page) || 1;
@@ -150,6 +151,7 @@ router.get('/search/:keyword?', async (req, res, next) => {
 });
 
 // GET list of work ids, restricted by circle/tag/VA
+// eslint-disable-next-line no-unused-vars
 router.get('/:field/:id', async (req, res, next) => {
   const currentPage = parseInt(req.query.page) || 1;
   // 通过 "音声id, 贩卖日, 用户评价, 售出数, 评论数量, 价格, 平均评价, 全年龄新作" 排序

--- a/routes/review.js
+++ b/routes/review.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { config } = require('../config');
 const db = require('../database/db');
+const normalize = require('./utils/normalize');
 
 const PAGE_SIZE = config.pageSize || 12;
 
@@ -18,6 +19,8 @@ router.get('/', async (req, res, next) => {
   
   try {
     const {works, totalCount} = await db.getWorksWithReviews({username: username, limit: PAGE_SIZE, offset: offset, orderBy: order, sortOption: sort, filter});
+
+    normalize(works, {dateOnly: true});
 
     res.send({
       works,

--- a/routes/utils/normalize.js
+++ b/routes/utils/normalize.js
@@ -1,0 +1,22 @@
+const strftime  = require('./strftime')
+
+// Normalize API endpoints
+const normalize = (works, options = {}) => {
+  works.map(record => {
+    record.nsfw = Boolean(record.nsfw);
+    record.circle = JSON.parse(record.circleObj);
+    record.rate_count_detail = JSON.parse(record.rate_count_detail);
+    record.rank = record.rank ? JSON.parse(record.rank) : null;
+    record.vas = JSON.parse(record.vaObj)['vas'];
+    record.tags = JSON.parse(record.tagObj)['tags'];
+    delete record.circleObj;
+    delete record.vaObj;
+    delete record.tagObj;
+    if (options.dateOnly && record.updated_at) {
+      record.updated_at = strftime('%F', record.updated_at);
+    }
+  })
+  return works
+}
+
+module.exports = normalize;

--- a/routes/utils/strftime.js
+++ b/routes/utils/strftime.js
@@ -72,6 +72,4 @@ function strftime(sFormat, date) {
   });
 }
 
-module.exports = {
-  strftime
-};
+module.exports = strftime;


### PR DESCRIPTION
本次后端的迁移和前端是配套的，请同时进行二者的升级。前端cha0sCat/kikoeru-quasar#3   
本次在后端数据库只创建了一个整合静态数据的视图，并没有危险操作，遇到问题可以直接回滚代码。  

N+1查询指的是：当前端访问集合`/api/work`时得到的信息不足以生成用户能看的页面，所以每个作品方块只能继续访问`/api/work/:id`获取单个作品详细信息，于是渲染一个页面需要N+1次网络请求和数据库查询。而且由于后端的查询不统一而且有不少问题，导致性能低下甚至锁表。本次用一个统一的静态数据视图重构所有读取查询，SQLite查询时可能会对同样的子查询进行缓存，并且修复了之间历史遗留的各种有问题和低效的查询，有助于大幅加快访问速度并提高用户体验。

### 操作步骤：
1. 合并前端和后端的代码
2. `npm install -g knex-migrate`
3. `cd database && knex-migrate up`
4. 注意数据库视图创建以前的短暂时间里会有downtime。或者也可以离线操作。

### 主要变化
1. 修改错误处理中间件，输出错误到console.error
2. 日志增加时间戳
3. 取消不必要的transaction
4. 重构大多数读取查询，基于统一的静态视图进行查询
5. 消除N+1查询，将单个作品的信息加到集合/api/works内